### PR TITLE
Support vertical layout

### DIFF
--- a/prepare-kiosk.sh
+++ b/prepare-kiosk.sh
@@ -72,6 +72,7 @@ WantedBy=sysinit.target
 
 sudo sh -c "echo '
 dtparam=audio=on
+display_hdmi_rotate=0
 disable_splash=1
 disable_overscan=1
 


### PR DESCRIPTION
raspberry by default add `dtOverlay` parameter to config.txt file. If this parameter is specified (at least FKMS) version, it does not support vertical screen rotation. In order to remove default config value, we no longer append config.txt file, but completely rewrite it. only `dtparam=audio=on` is needed from original config. 

Also added explicit default value for screen rotation, so that electron code would not need to check if this value is present